### PR TITLE
add crosshair for highlighted footprint

### DIFF
--- a/src/platform/assets/ibom.html
+++ b/src/platform/assets/ibom.html
@@ -107,6 +107,10 @@
             Continuous redraw on drag
           </label>
           <label class="menu-label">
+            <input id="crosshairCheckbox" type="checkbox" checked onchange="setShowCrosshair(this.checked)">
+            Show Crosshair
+          </label>
+          <label class="menu-label">
             <span>Board rotation</span>
             <span style="float: right"><span id="rotationDegree">0</span>&#176;</span>
             <input id="boardRotation" type="range" min="-36" max="36" value="0" class="slider" oninput="setBoardRotation(this.value)">

--- a/src/platform/assets/render.js
+++ b/src/platform/assets/render.js
@@ -351,6 +351,21 @@ function drawFootprint(ctx, layer, scalefactor, footprint, padColor, padHoleColo
       drawPadHole(ctx, pad, padHoleColor);
     }
   }
+  // draw crosshair
+  if (highlight && settings.showCrosshair) {
+    ctx.globalAlpha = 0.75;
+    ctx.lineWidth = 4 / scalefactor;
+    ctx.strokeStyle = padColor;
+    ctx.beginPath();
+    ctx.moveTo(footprint.center[0]-4000, footprint.center[1]);
+    ctx.lineTo(footprint.center[0]+4000, footprint.center[1]);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(footprint.center[0], footprint.center[1]-4000);
+    ctx.lineTo(footprint.center[0], footprint.center[1]+4000);
+    ctx.stroke();
+    ctx.globalAlpha = 1;
+  }
 }
 
 function drawEdgeCuts(canvas, scalefactor) {
@@ -975,6 +990,11 @@ function addMouseHandlers(div, layerdict) {
 function setRedrawOnDrag(value) {
   settings.redrawOnDrag = value;
   writeStorage("redrawOnDrag", value);
+}
+
+function setShowCrosshair(value) {
+  settings.showCrosshair = value;
+  writeStorage("showCrosshair", value);
 }
 
 function setBoardRotation(value) {

--- a/src/platform/assets/util.js
+++ b/src/platform/assets/util.js
@@ -456,6 +456,8 @@ function overwriteSettings(newSettings) {
   document.getElementById("dnpOutlineCheckbox").checked = settings.renderDnpOutline;
   setRedrawOnDrag(settings.redrawOnDrag);
   document.getElementById("dragCheckbox").checked = settings.redrawOnDrag;
+  setShowCrosshair(settings.showCrosshair);
+  document.getElementById("crosshairCheckbox").checked = settings.showCrosshair;
   setDarkMode(settings.darkMode);
   document.getElementById("darkmodeCheckbox").checked = settings.darkMode;
   setHighlightPin1(settings.highlightpin1);
@@ -560,6 +562,7 @@ function initDefaults() {
   }
   initBooleanSetting("dnpOutline", false, "dnpOutlineCheckbox", dnpOutline);
   initBooleanSetting("redrawOnDrag", config.redraw_on_drag, "dragCheckbox", setRedrawOnDrag);
+  initBooleanSetting("showCrosshair", config.show_crosshair, "crosshairCheckbox", setShowCrosshair);
   initBooleanSetting("darkmode", config.dark_mode, "darkmodeCheckbox", setDarkMode);
   initBooleanSetting("highlightpin1", config.highlight_pin1, "highlightpin1Checkbox", setHighlightPin1);
   settings.boardRotation = readStorage("boardRotation");


### PR DESCRIPTION
Optionally adds a crosshair to the highlighted component. Can be especially useful for small components on a huge PCB.

![2021-06-05 19_43_39-EasyEDA(Standard) - A Simple and Powerful Electronic Circuit Design Tool](https://user-images.githubusercontent.com/8081353/120900680-72b61000-c636-11eb-886d-49848ffc9767.png)